### PR TITLE
FUSETOOLS-3387 - activate non-OpensShift templates for fuse 7.8

### DIFF
--- a/configuration/camel2bom.fuse71.properties
+++ b/configuration/camel2bom.fuse71.properties
@@ -7,3 +7,5 @@
 2.21.0.fuse-750033-redhat-00001=7.5.0.fuse-750029-redhat-00002
 2.21.0.fuse-760027-redhat-00001=7.6.0.fuse-760027-redhat-00001
 2.21.0.fuse-770013-redhat-00001=7.7.0.fuse-770012-redhat-00003
+# it has switched to sb2 with Fuse 7.8
+2.23.2.fuse-780036-redhat-00001=7.8.0.fuse-sb2-780038-redhat-00001

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelCatalogUtils.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelCatalogUtils.java
@@ -150,7 +150,6 @@ public class CamelCatalogUtils {
 	public static List<String> getCamelVersionsToTestWithForNonOpenShiftTemplates() {
 		List<String> toTest = new ArrayList<>(TEST_CAMEL_VERSIONS);
 		toTest.remove(CAMEL_VERSION_LATEST_COMMUNITY);
-		toTest.remove(CamelForFuseOnOpenShiftToBomMapper.FUSE_780_CAMEL_VERSION);
 		return toTest;
 	}
 	

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/medium/CXfCodeFirstProjectTemplateForFuse76.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/medium/CXfCodeFirstProjectTemplateForFuse76.java
@@ -21,7 +21,7 @@ import org.fusesource.ide.projecttemplates.wizards.pages.model.EnvironmentData;
 public class CXfCodeFirstProjectTemplateForFuse76 extends AbstractCxfCodeFirstProjectTemplate {
 
 	private static final String MINIMAL_COMPATIBLE_CAMEL_VERSION = "2.21.0.fuse-760";
-	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2";
+	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2.fuse-77";
 
 	@Override
 	public TemplateConfiguratorSupport getConfigurator() {

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/CBRTemplateForFuse76.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/CBRTemplateForFuse76.java
@@ -20,7 +20,7 @@ import org.fusesource.ide.projecttemplates.wizards.pages.model.EnvironmentData;
 
 public class CBRTemplateForFuse76 extends AbstractCBRTemplate {
 
-	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2";
+	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2.fuse-77";
 	private static final String MINIMAL_COMPATIBLE_CAMEL_VERSION = "2.21.0.fuse-760";
 
 	@Override

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/EAPSpringTemplateForFuse71.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/EAPSpringTemplateForFuse71.java
@@ -21,7 +21,7 @@ import org.fusesource.ide.projecttemplates.wizards.pages.model.EnvironmentData;
 public class EAPSpringTemplateForFuse71 extends AbstractEAPSpringTemplate {
 
 	private static final String MINIMAL_COMPATIBLE_CAMEL_VERSION = "2.21.0.fuse-710";
-	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2";
+	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2.fuse-77";
 	
 	@Override
 	public TemplateConfiguratorSupport getConfigurator() {

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/EmptyProjectTemplateForFuse76.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/EmptyProjectTemplateForFuse76.java
@@ -21,7 +21,7 @@ import org.fusesource.ide.projecttemplates.wizards.pages.model.EnvironmentData;
 public class EmptyProjectTemplateForFuse76 extends AbstractEmptyProjectTemplate {
 	
 	private static final String MINIMAL_COMPATIBLE_CAMEL_VERSION = "2.21.0.fuse-760";
-	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2";
+	private static final String FUSE_7_7_INCOMPATIBLE_CAMEL_VERSION = "2.23.2.fuse-77";
 
 	@Override
 	public TemplateConfiguratorSupport getConfigurator() {


### PR DESCRIPTION
- reactivate tests
- in Fuse 7.7, there was no version for SpringBoot2. Now there is only
version for SpringBoot 2

